### PR TITLE
best practice installation notes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,15 +3,25 @@ Documentation https://wonde.com/docs/api/1.0/
 
 ## Installation
 
+Native gem:
+
 ```bash
 gem install wondeclient
 ```
 
-or from source
-```bash
-gem build WondeClient.gemspec
-gem install wondeclient-0.0.1.gem
+When using [bundler](http://bundler.io/) place this to your `Gemfile`:
+
+```ruby
+gem 'wondeclient'
 ```
+
+Or if you want to use latest github `master`
+
+```ruby
+gem 'wondeclient', github: 'wondeltd/ruby-client'
+```
+
+... and run `$ bundle install`
 
 ## Early Release
 


### PR DESCRIPTION
this is proffered way how to install Ruby gems in the Ruby community, No one compiles from source, and if they need to have local copy of gem Ruby developers  will  clone the repo to local folder and specify `gem 'wondeclient', path: '/home/myusr/my-dir/ruby-client'`