### PR TITLE
Specify bearer authorization

### DIFF
--- a/lib/endpoints.rb
+++ b/lib/endpoints.rb
@@ -38,7 +38,7 @@ module Wonde
         method: :get,
         url: url,
         headers: {
-          "Authorization" => "Basic #{self.token}",
+          "Authorization" => "Bearer #{self.token}",
           "User-Agent" => "wonde-rb-client-#{self.version}"
         }
       )


### PR DESCRIPTION
Specifies use of HTTP Bearer auth, similar to the .NET client and in API docs.

The client currently specifies basic auth while providing an unmodified access token. We have observed that, in combination with a recently generated access key, this results in a 500 error response.

Presumably the ruby client behaviour should be either:
- specify "Authorization: Bearer" and provide the token unmodified, per .NET client & sync API docs
- specify "Authorization: Basic" and provide base64("[TOKEN]" + ":"), per php client