### PR TITLE
Bugfix/school get

### DIFF
--- a/lib/endpoints.rb
+++ b/lib/endpoints.rb
@@ -65,7 +65,7 @@ module Wonde
       puts response if ENV["debug_wonde"]
       object = JSON.parse(response, object_class: OpenStruct)
       puts object if ENV["debug_wonde"]
-      object
+      object.data
     end
 
     def postRequest(endpoint, body=Hash.new())

--- a/lib/endpoints.rb
+++ b/lib/endpoints.rb
@@ -61,7 +61,7 @@ module Wonde
       else
         uri = self.uri + id
       end
-      response = getRequest(uri).body["data"]
+      response = getRequest(uri).body
       puts response if ENV["debug_wonde"]
       object = JSON.parse(response, object_class: OpenStruct)
       puts object if ENV["debug_wonde"]


### PR DESCRIPTION
Calling: client.get.schools.get("A1930499544")

Results in:

Traceback (most recent call last):
1: from (irb):6
JSON::ParserError (783: unexpected token at 'data')

It appears the api client expects an object but gets a string. This change matches code in all around line 144.

Note: I've not run the tests or evaluated any other impacts of this change...

