### PR TITLE
Get single employee

### DIFF
--- a/lib/endpoints/employees.rb
+++ b/lib/endpoints/employees.rb
@@ -5,7 +5,7 @@ module Wonde
       super(token, id)
       self.uri = @@uri
       self.uri = id + '/' + @@uri if id
-      self.uri = self.uri.gsub("//", "/").chomp("/")
+      self.uri = self.uri.gsub("//", "/")
     end
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -330,6 +330,9 @@ client = Wonde::Client.new('TOKEN_GOES_HERE')
 
 school = client.school('SCHOOL_ID_GOES_HERE')
 
+# Get single employee
+employee = school.employees.get('EMPLOYEE_ID_GOES_HERE')
+
 # Get employees
 school.employees.all().each do |employee|
     p employee.forename + ' ' + employee.surname


### PR DESCRIPTION
Fixes bug where using `school.employees.get('EMPLOYEE_ID_GOES_HERE')` would result in the endpoint chomping the trailing slash on the employee endpoint e.g. it would try to request `/employeesEMPLOYEE_ID` rather than `/employees/EMPLOYEE_ID`.

Updated to match what the students endpoint and added an example for the readme.
